### PR TITLE
Feature/date range without long press

### DIFF
--- a/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
+++ b/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
@@ -46,6 +46,24 @@ import java.util.Calendar;
 
 public class Sampler extends AppCompatActivity {
 
+    // Keys for saving state
+    private static final String SS_DATE_PICKER_CHECKED = "saved.state.date.picker.checked";
+    private static final String SS_TIME_PICKER_CHECKED = "saved.state.time.picker.checked";
+    private static final String SS_RECURRENCE_PICKER_CHECKED = "saved.state.recurrence.picker.checked";
+    private static final String SS_ALLOW_DATE_RANGE_SELECTION = "saved.state.allow.date.range.selection";
+    private static final String SS_TOGGLE_DATE_RANGE_SELECTION_WITHOUT_LONG_PRESS = "saved.state.allow.date.range.selection.without.longpress";
+    private static final String SS_START_YEAR = "saved.state.start.year";
+    private static final String SS_START_MONTH = "saved.state.start.month";
+    private static final String SS_START_DAY = "saved.state.start.day";
+    private static final String SS_END_YEAR = "saved.state.end.year";
+    private static final String SS_END_MONTH = "saved.state.end.month";
+    private static final String SS_END_DAY = "saved.state.end.day";
+    private static final String SS_HOUR = "saved.state.hour";
+    private static final String SS_MINUTE = "saved.state.minute";
+    private static final String SS_RECURRENCE_OPTION = "saved.state.recurrence.option";
+    private static final String SS_RECURRENCE_RULE = "saved.state.recurrence.rule";
+    private static final String SS_INFO_VIEW_VISIBILITY = "saved.state.info.view.visibility";
+    private static final String SS_SCROLL_Y = "saved.state.scroll.y";
     private final int INVALID_VAL = -1;
 
     // Launches SublimePicker
@@ -426,25 +444,6 @@ public class Sampler extends AppCompatActivity {
                 Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         return ss;
     }
-
-    // Keys for saving state
-    final String SS_DATE_PICKER_CHECKED = "saved.state.date.picker.checked";
-    final String SS_TIME_PICKER_CHECKED = "saved.state.time.picker.checked";
-    final String SS_RECURRENCE_PICKER_CHECKED = "saved.state.recurrence.picker.checked";
-    final String SS_ALLOW_DATE_RANGE_SELECTION = "saved.state.allow.date.range.selection";
-    final String SS_TOGGLE_DATE_RANGE_SELECTION_WITHOUT_LONG_PRESS = "saved.state.allow.date.range.selection.without.longpress";
-    final String SS_START_YEAR = "saved.state.start.year";
-    final String SS_START_MONTH = "saved.state.start.month";
-    final String SS_START_DAY = "saved.state.start.day";
-    final String SS_END_YEAR = "saved.state.end.year";
-    final String SS_END_MONTH = "saved.state.end.month";
-    final String SS_END_DAY = "saved.state.end.day";
-    final String SS_HOUR = "saved.state.hour";
-    final String SS_MINUTE = "saved.state.minute";
-    final String SS_RECURRENCE_OPTION = "saved.state.recurrence.option";
-    final String SS_RECURRENCE_RULE = "saved.state.recurrence.rule";
-    final String SS_INFO_VIEW_VISIBILITY = "saved.state.info.view.visibility";
-    final String SS_SCROLL_Y = "saved.state.scroll.y";
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {

--- a/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
+++ b/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
@@ -52,7 +52,7 @@ public class Sampler extends AppCompatActivity {
     ImageView ivLaunchPicker;
 
     // SublimePicker options
-    CheckBox cbDatePicker, cbTimePicker, cbRecurrencePicker, cbAllowDateRangeSelection;
+    CheckBox cbDatePicker, cbTimePicker, cbRecurrencePicker, cbAllowDateRangeSelection, cbToggleRangeSelectionWithoutLongPress;
     RadioButton rbDatePicker, rbTimePicker, rbRecurrencePicker;
 
     // Labels
@@ -137,6 +137,7 @@ public class Sampler extends AppCompatActivity {
         svMainContainer = (ScrollView) findViewById(R.id.svMainContainer);
 
         cbAllowDateRangeSelection = (CheckBox) findViewById(R.id.cbAllowDateRangeSelection);
+        cbToggleRangeSelectionWithoutLongPress = (CheckBox) findViewById(R.id.cbToggleRangeSelectionWithoutLongPress);
 
         llDateHolder = (LinearLayout) findViewById(R.id.llDateHolder);
         llDateRangeHolder = (LinearLayout) findViewById(R.id.llDateRangeHolder);
@@ -232,6 +233,7 @@ public class Sampler extends AppCompatActivity {
             cbTimePicker.setChecked(true);
             cbRecurrencePicker.setChecked(true);
             cbAllowDateRangeSelection.setChecked(false);
+            cbToggleRangeSelectionWithoutLongPress.setChecked(false);
 
             rbDatePicker.setChecked(true);
         } else { // Restore
@@ -241,6 +243,7 @@ public class Sampler extends AppCompatActivity {
                     .setChecked(savedInstanceState.getBoolean(SS_RECURRENCE_PICKER_CHECKED));
             cbAllowDateRangeSelection
                     .setChecked(savedInstanceState.getBoolean(SS_ALLOW_DATE_RANGE_SELECTION));
+            cbToggleRangeSelectionWithoutLongPress.setChecked(savedInstanceState.getBoolean(SS_TOGGLE_DATE_RANGE_SELECTION_WITHOUT_LONG_PRESS));
 
             rbDatePicker.setVisibility(cbDatePicker.isChecked() ?
                     View.VISIBLE : View.GONE);
@@ -324,6 +327,7 @@ public class Sampler extends AppCompatActivity {
 
         // Enable/disable the date range selection feature
         options.setCanPickDateRange(cbAllowDateRangeSelection.isChecked());
+        options.setToggleRangeWithoutLongPress(cbToggleRangeSelectionWithoutLongPress.isChecked());
 
         // Example for setting date range:
         // Note that you can pass a date range as the initial date params
@@ -428,6 +432,7 @@ public class Sampler extends AppCompatActivity {
     final String SS_TIME_PICKER_CHECKED = "saved.state.time.picker.checked";
     final String SS_RECURRENCE_PICKER_CHECKED = "saved.state.recurrence.picker.checked";
     final String SS_ALLOW_DATE_RANGE_SELECTION = "saved.state.allow.date.range.selection";
+    final String SS_TOGGLE_DATE_RANGE_SELECTION_WITHOUT_LONG_PRESS = "saved.state.allow.date.range.selection.without.longpress";
     final String SS_START_YEAR = "saved.state.start.year";
     final String SS_START_MONTH = "saved.state.start.month";
     final String SS_START_DAY = "saved.state.start.day";
@@ -449,6 +454,7 @@ public class Sampler extends AppCompatActivity {
         outState.putBoolean(SS_TIME_PICKER_CHECKED, cbTimePicker.isChecked());
         outState.putBoolean(SS_RECURRENCE_PICKER_CHECKED, cbRecurrencePicker.isChecked());
         outState.putBoolean(SS_ALLOW_DATE_RANGE_SELECTION, cbAllowDateRangeSelection.isChecked());
+        outState.putBoolean(SS_TOGGLE_DATE_RANGE_SELECTION_WITHOUT_LONG_PRESS, cbToggleRangeSelectionWithoutLongPress.isChecked());
 
         int startYear = mSelectedDate != null ? mSelectedDate.getStartDate().get(Calendar.YEAR) : INVALID_VAL;
         int startMonth = mSelectedDate != null ? mSelectedDate.getStartDate().get(Calendar.MONTH) : INVALID_VAL;

--- a/app/src/main/res/layout/sampler.xml
+++ b/app/src/main/res/layout/sampler.xml
@@ -133,6 +133,16 @@
                 android:text="Allow date range selection?"
                 android:textSize="@dimen/sampler_text_size" />
 
+            <CheckBox
+                android:id="@+id/cbToggleRangeSelectionWithoutLongPress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                android:layout_marginBottom="20dp"
+                android:text="Allow date range selection without long press?"
+                android:textSize="@dimen/sampler_text_size" />
+
             <RelativeLayout
                 android:id="@+id/rlDateTimeRecurrenceInfo"
                 android:layout_width="match_parent"

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/SublimePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/SublimePicker.java
@@ -555,7 +555,7 @@ public class SublimePicker extends FrameLayout
             //        dateParams[2] /* day of month */,
             //        mOptions.canPickDateRange(),
             //        this);
-            mDatePicker.init(mOptions.getDateParams(), mOptions.canPickDateRange(), this);
+            mDatePicker.init(mOptions.getDateParams(), mOptions.canPickDateRange(), mOptions.canToggleRangeWithoutLongPress(), this);
 
             long[] dateRange = mOptions.getDateRange();
 
@@ -636,7 +636,7 @@ public class SublimePicker extends FrameLayout
                 //selectedDate.getStartDate().get(Calendar.MONTH),
                 //selectedDate.getStartDate().get(Calendar.DAY_OF_MONTH),
                 //mOptions.canPickDateRange(), this);
-        mDatePicker.init(selectedDate, mOptions.canPickDateRange(), this);
+        mDatePicker.init(selectedDate, mOptions.canPickDateRange(), mOptions.canToggleRangeWithoutLongPress(), this);
     }
 
     @Override

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerView.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerView.java
@@ -229,6 +229,10 @@ class DayPickerView extends ViewGroup {
         mViewPager.setCanPickRange(canPickRange);
     }
 
+    public void setToggleRangeWithoutLongPress(boolean setToggleRangeWithoutLongPress) {
+        mViewPager.setToggleRangeWithoutLongPress(setToggleRangeWithoutLongPress);
+    }
+
     private void updateButtonVisibility(int position) {
         final boolean hasPrev = position > 0;
         final boolean hasNext = position < (mAdapter.getCount() - 1);

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerViewPager.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerViewPager.java
@@ -19,6 +19,8 @@ package com.appeaser.sublimepickerlibrary.datepicker;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
@@ -58,6 +60,7 @@ class DayPickerViewPager extends ViewPager {
     private boolean toggleRange = false;
     private boolean mCanToggleRangeWithoutLongPress = false;
     private CheckForLongPress mCheckForLongPress;
+    @Nullable
     private SelectedDate mTempSelectedDate;
 
     // Scrolling support
@@ -307,8 +310,8 @@ class DayPickerViewPager extends ViewPager {
                     mTempSelectedDate = mDayPickerPagerAdapter.resolveEndDateForRange((int) ev.getX(),
                             (int) ev.getY(), getCurrentItem(), false);
 
-                    if (mCanToggleRangeWithoutLongPress) {
-                        toggleLongSelectAction();
+                    if (mCanToggleRangeWithoutLongPress && mTempSelectedDate != null) {
+                        mTempSelectedDate = toggleLongSelectAction(mTempSelectedDate);
                     }
 
                     mDayPickerPagerAdapter.onDateRangeSelectionEnded(mTempSelectedDate);
@@ -367,11 +370,13 @@ class DayPickerViewPager extends ViewPager {
         return isRangeSelectionActive() || super.onTouchEvent(ev);
     }
 
-    private void toggleLongSelectAction() {
+    @NonNull
+    private SelectedDate toggleLongSelectAction(@NonNull final SelectedDate selectedDate) {
         if (toggleRange) {
-            mTempSelectedDate.setFirstDate(mTempSelectedDate.getSecondDate());
+            selectedDate.setFirstDate(selectedDate.getSecondDate());
         }
         toggleRange = !toggleRange;
+        return selectedDate;
     }
 
     private boolean isRangeSelectionActive() {

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerViewPager.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/DayPickerViewPager.java
@@ -372,7 +372,7 @@ class DayPickerViewPager extends ViewPager {
 
     @NonNull
     private SelectedDate toggleLongSelectAction(@NonNull final SelectedDate selectedDate) {
-        if (toggleRange) {
+        if (!toggleRange) {
             selectedDate.setFirstDate(selectedDate.getSecondDate());
         }
         toggleRange = !toggleRange;

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
@@ -514,21 +514,21 @@ public class SublimeDatePicker extends FrameLayout {
     /**
      * Initialize the state. If the provided values designate an inconsistent
      * date the values are normalized before updating the spinners.
-     *
-     * @param selectedDate  The initial date or date range.
+     *  @param selectedDate  The initial date or date range.
      * @param canPickRange  Enable/disable date range selection
+     * @param setToggleRangeWithoutLongPress Enable/disable date range selection without long press
      * @param callback      How user is notified date is changed by
-     *                      user, can be null.
      */
     //public void init(int year, int monthOfYear, int dayOfMonth, boolean canPickRange,
     public void init(SelectedDate selectedDate, boolean canPickRange,
-                     SublimeDatePicker.OnDateChangedListener callback) {
+                     boolean setToggleRangeWithoutLongPress, OnDateChangedListener callback) {
         //mCurrentDate.set(Calendar.YEAR, year);
         //mCurrentDate.set(Calendar.MONTH, monthOfYear);
         //mCurrentDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
         mCurrentDate = new SelectedDate(selectedDate);
 
         mDayPickerView.setCanPickRange(canPickRange);
+        mDayPickerView.setToggleRangeWithoutLongPress(setToggleRangeWithoutLongPress);
         mDateChangedListener = callback;
 
         onDateChanged(false, false, true);

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/helpers/SublimeOptions.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/helpers/SublimeOptions.java
@@ -60,6 +60,8 @@ public class SublimeOptions implements Parcelable {
 
     // Allow date range selection
     private boolean mCanPickDateRange;
+    // Allow date range selection without long presses
+    private boolean mToggleRangeWithoutLongPress;
 
     // Defaults
     private Picker mPickerToShow = Picker.DATE_PICKER;
@@ -313,6 +315,19 @@ public class SublimeOptions implements Parcelable {
         return mCanPickDateRange;
     }
 
+    public SublimeOptions setToggleRangeWithoutLongPress(boolean toggleRangeWithoutLongPress) {
+        this.mToggleRangeWithoutLongPress = toggleRangeWithoutLongPress;
+        if (toggleRangeWithoutLongPress) {
+            return setCanPickDateRange(true);
+        } else {
+            return this;
+        }
+    }
+
+    public boolean canToggleRangeWithoutLongPress() {
+        return mToggleRangeWithoutLongPress;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -333,6 +348,7 @@ public class SublimeOptions implements Parcelable {
         mIs24HourView = in.readByte() != 0;
         mRecurrenceRule = in.readString();
         mCanPickDateRange = in.readByte() != 0;
+        mToggleRangeWithoutLongPress = in.readByte() != 0;
     }
 
     @Override
@@ -351,6 +367,7 @@ public class SublimeOptions implements Parcelable {
         dest.writeByte((byte) (mIs24HourView ? 1 : 0));
         dest.writeString(mRecurrenceRule);
         dest.writeByte((byte) (mCanPickDateRange ? 1 : 0));
+        dest.writeByte((byte) (mToggleRangeWithoutLongPress ? 1 : 0));
     }
 
     public static final Parcelable.Creator<SublimeOptions> CREATOR = new Parcelable.Creator<SublimeOptions>() {


### PR DESCRIPTION
This resolves issue #53 . 
```SublimeOptions``` have been modified to change behaviour between existing long press for date range selection and 2 taps for range selection.

Use the option ```SublimeOptions.setToggleRangeWithoutLongPress(true)``` when initializing ```SublimePicker```.