### PR TITLE
Fix: Options other than 'Custom' are not selectable in 'REPEAT_OPTION…

### DIFF
--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/recurrencepicker/SublimeRecurrencePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/recurrencepicker/SublimeRecurrencePicker.java
@@ -353,12 +353,13 @@ public class SublimeRecurrencePicker extends FrameLayout
         } else if (v.getId() == R.id.tvCustom) {
             // Show RecurrenceOptionCreator
             mCurrentView = CurrentView.RECURRENCE_CREATOR;
-            updateView();
-            return;
         } else {
             // Default
             mCurrentRecurrenceOption = RecurrenceOption.DOES_NOT_REPEAT;
         }
+
+        updateView();
+        if(v.getId() == R.id.tvCustom) return;
 
         if (mCallback != null) {
             // A preset value has been picked.


### PR DESCRIPTION
…_PICKER', MORE

This occurs when the following options are set for 'SublimeOptions':

	sublimeOptions.setPickerToShow(SublimeOptions.Picker.REPEAT_OPTION_PICKER)
	sublimeOptions.setDisplayOptions(SublimeOptions.ACTIVATE_RECURRENCE_PICKER)

Steps to reproduce:

	1. Create a sublime picker instance with the options above set.
	2. Attempt to click any options other than 'Custom'

	Notice that options other than 'Custom' are not selectable.