### PR TITLE
Added an alternate range selection mode

### DIFF
--- a/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
+++ b/app/src/main/java/com/appeaser/sublimepicker/Sampler.java
@@ -29,6 +29,7 @@ import android.text.style.StyleSpan;
 import android.util.Pair;
 import android.view.View;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
@@ -52,7 +53,7 @@ public class Sampler extends AppCompatActivity {
     ImageView ivLaunchPicker;
 
     // SublimePicker options
-    CheckBox cbDatePicker, cbTimePicker, cbRecurrencePicker, cbAllowDateRangeSelection;
+    CheckBox cbDatePicker, cbTimePicker, cbRecurrencePicker, cbAllowDateRangeSelection, cbAlternateSelection;
     RadioButton rbDatePicker, rbTimePicker, rbRecurrencePicker;
 
     // Labels
@@ -137,6 +138,7 @@ public class Sampler extends AppCompatActivity {
         svMainContainer = (ScrollView) findViewById(R.id.svMainContainer);
 
         cbAllowDateRangeSelection = (CheckBox) findViewById(R.id.cbAllowDateRangeSelection);
+        cbAlternateSelection = (CheckBox) findViewById(R.id.cbAlternateSelection);
 
         llDateHolder = (LinearLayout) findViewById(R.id.llDateHolder);
         llDateRangeHolder = (LinearLayout) findViewById(R.id.llDateRangeHolder);
@@ -222,6 +224,18 @@ public class Sampler extends AppCompatActivity {
             }
         });
 
+        cbAllowDateRangeSelection.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean isSelected) {
+                if (isSelected) {
+                    cbAlternateSelection.setVisibility(View.VISIBLE);
+                } else {
+                    cbAlternateSelection.setChecked(false);
+                    cbAlternateSelection.setVisibility(View.GONE);
+                }
+            }
+        });
+
         // restore state
         dealWithSavedInstanceState(savedInstanceState);
     }
@@ -232,6 +246,7 @@ public class Sampler extends AppCompatActivity {
             cbTimePicker.setChecked(true);
             cbRecurrencePicker.setChecked(true);
             cbAllowDateRangeSelection.setChecked(false);
+            cbAlternateSelection.setChecked(false);
 
             rbDatePicker.setChecked(true);
         } else { // Restore
@@ -241,6 +256,8 @@ public class Sampler extends AppCompatActivity {
                     .setChecked(savedInstanceState.getBoolean(SS_RECURRENCE_PICKER_CHECKED));
             cbAllowDateRangeSelection
                     .setChecked(savedInstanceState.getBoolean(SS_ALLOW_DATE_RANGE_SELECTION));
+            cbAlternateSelection
+                    .setChecked(savedInstanceState.getBoolean(SS_ALLOW_ALTERNATE_DATE_SELECTION));
 
             rbDatePicker.setVisibility(cbDatePicker.isChecked() ?
                     View.VISIBLE : View.GONE);
@@ -324,6 +341,9 @@ public class Sampler extends AppCompatActivity {
 
         // Enable/disable the date range selection feature
         options.setCanPickDateRange(cbAllowDateRangeSelection.isChecked());
+
+        //enable alternate date selection
+        options.setAlternateSelectionMode(cbAlternateSelection.isChecked());
 
         // Example for setting date range:
         // Note that you can pass a date range as the initial date params
@@ -428,6 +448,7 @@ public class Sampler extends AppCompatActivity {
     final String SS_TIME_PICKER_CHECKED = "saved.state.time.picker.checked";
     final String SS_RECURRENCE_PICKER_CHECKED = "saved.state.recurrence.picker.checked";
     final String SS_ALLOW_DATE_RANGE_SELECTION = "saved.state.allow.date.range.selection";
+    final String SS_ALLOW_ALTERNATE_DATE_SELECTION = "saved.state.allow.alternate.date.selection";
     final String SS_START_YEAR = "saved.state.start.year";
     final String SS_START_MONTH = "saved.state.start.month";
     final String SS_START_DAY = "saved.state.start.day";
@@ -449,6 +470,7 @@ public class Sampler extends AppCompatActivity {
         outState.putBoolean(SS_TIME_PICKER_CHECKED, cbTimePicker.isChecked());
         outState.putBoolean(SS_RECURRENCE_PICKER_CHECKED, cbRecurrencePicker.isChecked());
         outState.putBoolean(SS_ALLOW_DATE_RANGE_SELECTION, cbAllowDateRangeSelection.isChecked());
+        outState.putBoolean(SS_ALLOW_ALTERNATE_DATE_SELECTION, cbAlternateSelection.isChecked());
 
         int startYear = mSelectedDate != null ? mSelectedDate.getStartDate().get(Calendar.YEAR) : INVALID_VAL;
         int startMonth = mSelectedDate != null ? mSelectedDate.getStartDate().get(Calendar.MONTH) : INVALID_VAL;

--- a/app/src/main/res/layout/sampler.xml
+++ b/app/src/main/res/layout/sampler.xml
@@ -121,17 +121,29 @@
                 android:paddingLeft="20dp"
                 android:textStyle="bold"
                 android:textSize="@dimen/sampler_text_size" />
+        <LinearLayout
+            android:paddingLeft="20dp"
+            android:paddingTop="10dp"
+            android:paddingRight="20dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <CheckBox
                 android:id="@+id/cbAllowDateRangeSelection"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="20dp"
-                android:layout_marginTop="10dp"
-                android:layout_marginRight="20dp"
-                android:layout_marginBottom="20dp"
                 android:text="Allow date range selection?"
                 android:textSize="@dimen/sampler_text_size" />
+
+            <CheckBox
+                android:id="@+id/cbAlternateSelection"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Alternate range selection"
+                android:textSize="@dimen/sampler_text_size" />
+        </LinearLayout>
+
 
             <RelativeLayout
                 android:id="@+id/rlDateTimeRecurrenceInfo"

--- a/app/src/main/res/layout/sampler.xml
+++ b/app/src/main/res/layout/sampler.xml
@@ -140,6 +140,7 @@
                 android:id="@+id/cbAlternateSelection"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:visibility="invisible"
                 android:text="Alternate range selection"
                 android:textSize="@dimen/sampler_text_size" />
         </LinearLayout>

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/SublimePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/SublimePicker.java
@@ -555,7 +555,7 @@ public class SublimePicker extends FrameLayout
             //        dateParams[2] /* day of month */,
             //        mOptions.canPickDateRange(),
             //        this);
-            mDatePicker.init(mOptions.getDateParams(), mOptions.canPickDateRange(), this);
+            mDatePicker.init(mOptions.getDateParams(), mOptions.canPickDateRange(), mOptions.isAlternateSelectionMode(),this);
 
             long[] dateRange = mOptions.getDateRange();
 
@@ -636,7 +636,7 @@ public class SublimePicker extends FrameLayout
                 //selectedDate.getStartDate().get(Calendar.MONTH),
                 //selectedDate.getStartDate().get(Calendar.DAY_OF_MONTH),
                 //mOptions.canPickDateRange(), this);
-        mDatePicker.init(selectedDate, mOptions.canPickDateRange(), this);
+        mDatePicker.init(selectedDate, mOptions.canPickDateRange(), mOptions.isAlternateSelectionMode(),this);
     }
 
     @Override

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SelectedDate.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SelectedDate.java
@@ -64,6 +64,10 @@ public class SelectedDate {
         return compareDates(mFirstDate, mSecondDate) == 0 ? Type.SINGLE : Type.RANGE;
     }
 
+    boolean isSingleDaySelected() {
+        return mFirstDate == mSecondDate;
+    }
+
     // a & b should never be null, so don't perform a null check here.
     // Let the source of error identify itself.
     public static int compareDates(Calendar a, Calendar b) {

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
@@ -405,23 +405,25 @@ public class SublimeDatePicker extends FrameLayout {
     private final OnClickListener mOnHeaderClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            SUtils.vibrateForDatePicker(SublimeDatePicker.this);
+            if (!isAlternateDatePicker) {
+                SUtils.vibrateForDatePicker(SublimeDatePicker.this);
 
-            if (v.getId() == R.id.date_picker_header_year) {
-                setCurrentView(VIEW_YEAR);
-            } else if (v.getId() == R.id.date_picker_header_date) {
-                setCurrentView(VIEW_MONTH_DAY);
-            } else if (v.getId() == R.id.tv_header_date_start) {
-                mCurrentlyActivatedRangeItem = RANGE_ACTIVATED_START;
-                tvHeaderDateStart.setActivated(true);
-                tvHeaderDateEnd.setActivated(false);
-            } else if (v.getId() == R.id.tv_header_date_end) {
-                mCurrentlyActivatedRangeItem = RANGE_ACTIVATED_END;
-                tvHeaderDateStart.setActivated(false);
-                tvHeaderDateEnd.setActivated(true);
-            } else if (v.getId() == R.id.iv_header_date_reset) {
-                mCurrentDate = new SelectedDate(mCurrentDate.getStartDate());
-                onDateChanged(true, false, true);
+                if (v.getId() == R.id.date_picker_header_year) {
+                    setCurrentView(VIEW_YEAR);
+                } else if (v.getId() == R.id.date_picker_header_date) {
+                    setCurrentView(VIEW_MONTH_DAY);
+                } else if (v.getId() == R.id.tv_header_date_start) {
+                    mCurrentlyActivatedRangeItem = RANGE_ACTIVATED_START;
+                    tvHeaderDateStart.setActivated(true);
+                    tvHeaderDateEnd.setActivated(false);
+                } else if (v.getId() == R.id.tv_header_date_end) {
+                    mCurrentlyActivatedRangeItem = RANGE_ACTIVATED_END;
+                    tvHeaderDateStart.setActivated(false);
+                    tvHeaderDateEnd.setActivated(true);
+                } else if (v.getId() == R.id.iv_header_date_reset) {
+                    mCurrentDate = new SelectedDate(mCurrentDate.getStartDate());
+                    onDateChanged(true, false, true);
+                }
             }
         }
     };
@@ -632,8 +634,13 @@ public class SublimeDatePicker extends FrameLayout {
         ivHeaderDateReset.setVisibility(View.VISIBLE);
         llHeaderDateRangeCont.setVisibility(View.VISIBLE);
 
-        tvHeaderDateStart.setActivated(mCurrentlyActivatedRangeItem == RANGE_ACTIVATED_START);
-        tvHeaderDateEnd.setActivated(mCurrentlyActivatedRangeItem == RANGE_ACTIVATED_END);
+        if (isAlternateDatePicker) {
+            tvHeaderDateStart.setActivated(true);
+            tvHeaderDateEnd.setActivated(true);
+        } else {
+            tvHeaderDateStart.setActivated(mCurrentlyActivatedRangeItem == RANGE_ACTIVATED_START);
+            tvHeaderDateEnd.setActivated(mCurrentlyActivatedRangeItem == RANGE_ACTIVATED_END);
+        }
     }
 
     public SelectedDate getSelectedDate() {

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
@@ -73,6 +73,7 @@ public class SublimeDatePicker extends FrameLayout {
     private static final int DEFAULT_END_YEAR = 2100;
 
     private boolean isAlternateDatePicker = false;
+    private boolean canPickRange = false;
 
     private Context mContext;
 
@@ -503,10 +504,10 @@ public class SublimeDatePicker extends FrameLayout {
             case VIEW_MONTH_DAY:
                 mDayPickerView.setDate(mCurrentDate);
 
-                if (mCurrentDate.getType() == SelectedDate.Type.SINGLE) {
-                    switchToSingleDateView();
-                } else {
+                if (canPickRange) {
                     switchToDateRangeView();
+                } else {
+                    switchToSingleDateView();
                 }
 
                 if (mCurrentView != viewIndex) {
@@ -540,6 +541,8 @@ public class SublimeDatePicker extends FrameLayout {
      * @param callback      How user is notified date is changed by
      *                      user, can be null.
      */
+
+
     //public void init(int year, int monthOfYear, int dayOfMonth, boolean canPickRange,
     public void init(SelectedDate selectedDate, boolean canPickRange, boolean isMultipleDayPicker,
                      SublimeDatePicker.OnDateChangedListener callback) {
@@ -547,6 +550,7 @@ public class SublimeDatePicker extends FrameLayout {
         //mCurrentDate.set(Calendar.MONTH, monthOfYear);
         //mCurrentDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
         mCurrentDate = new SelectedDate(selectedDate);
+        this.canPickRange = canPickRange;
         this.isAlternateDatePicker = isMultipleDayPicker;
         mDayPickerView.setCanPickRange(canPickRange);
         mDateChangedListener = callback;
@@ -601,10 +605,10 @@ public class SublimeDatePicker extends FrameLayout {
                     + mCurrentDate.getSecondDate().getTimeInMillis());
         }
 
-        if (mCurrentDate.getType() == SelectedDate.Type.SINGLE) {
-            switchToSingleDateView();
-        } else if (mCurrentDate.getType() == SelectedDate.Type.RANGE) {
+        if (canPickRange ) {
             switchToDateRangeView();
+        } else {
+            switchToSingleDateView();
         }
     }
 

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/datepicker/SublimeDatePicker.java
@@ -72,6 +72,8 @@ public class SublimeDatePicker extends FrameLayout {
     private static final int DEFAULT_START_YEAR = 1900;
     private static final int DEFAULT_END_YEAR = 2100;
 
+    private boolean isAlternateDatePicker = false;
+
     private Context mContext;
 
     private SimpleDateFormat mYearFormat;
@@ -298,25 +300,43 @@ public class SublimeDatePicker extends FrameLayout {
 
             boolean goToPosition = true;
 
+            // We're in Range selection mode
             if (llHeaderDateRangeCont.getVisibility() == View.VISIBLE) {
-                // We're in Range selection mode
-                if (tvHeaderDateStart.isActivated()) {
-                    if (SelectedDate.compareDates(day, mCurrentDate.getEndDate()) > 0) {
+                if (isAlternateDatePicker) {
+                    if (mCurrentDate == null) {
                         mCurrentDate = new SelectedDate(day);
                     } else {
-                        goToPosition = false;
-                        mCurrentDate = new SelectedDate(day, mCurrentDate.getEndDate());
+                        if (mCurrentDate.isSingleDaySelected()) { //we need to select a date range
+                            if (SelectedDate.compareDates(day, mCurrentDate.getStartDate()) < 0) {
+                                mCurrentDate = new SelectedDate(day, mCurrentDate.getEndDate());
+                            } else {
+                                if (SelectedDate.compareDates(day, mCurrentDate.getEndDate()) > 0) {
+                                    mCurrentDate = new SelectedDate(mCurrentDate.getStartDate(), day);
+                                }
+                            }
+                        } else {
+                            mCurrentDate = new SelectedDate(day);
+                        }
                     }
-                } else if (tvHeaderDateEnd.isActivated()) {
-                    if (SelectedDate.compareDates(day, mCurrentDate.getStartDate()) < 0) {
-                        mCurrentDate = new SelectedDate(day);
-                    } else {
-                        goToPosition = false;
-                        mCurrentDate = new SelectedDate(mCurrentDate.getStartDate(), day);
-                    }
-                } else { // Should never happen
-                    if (Config.DEBUG) {
-                        Log.i(TAG, "onDaySelected: Neither tvDateStart, nor tvDateEnd is activated");
+                } else {
+                    if (tvHeaderDateStart.isActivated()) {
+                        if (SelectedDate.compareDates(day, mCurrentDate.getEndDate()) > 0) {
+                            mCurrentDate = new SelectedDate(day);
+                        } else {
+                            goToPosition = false;
+                            mCurrentDate = new SelectedDate(day, mCurrentDate.getEndDate());
+                        }
+                    } else if (tvHeaderDateEnd.isActivated()) {
+                        if (SelectedDate.compareDates(day, mCurrentDate.getStartDate()) < 0) {
+                            mCurrentDate = new SelectedDate(day);
+                        } else {
+                            goToPosition = false;
+                            mCurrentDate = new SelectedDate(mCurrentDate.getStartDate(), day);
+                        }
+                    } else { // Should never happen
+                        if (Config.DEBUG) {
+                            Log.i(TAG, "onDaySelected: Neither tvDateStart, nor tvDateEnd is activated");
+                        }
                     }
                 }
             } else {
@@ -485,7 +505,7 @@ public class SublimeDatePicker extends FrameLayout {
 
                 if (mCurrentDate.getType() == SelectedDate.Type.SINGLE) {
                     switchToSingleDateView();
-                } else if (mCurrentDate.getType() == SelectedDate.Type.RANGE) {
+                } else {
                     switchToDateRangeView();
                 }
 
@@ -521,16 +541,15 @@ public class SublimeDatePicker extends FrameLayout {
      *                      user, can be null.
      */
     //public void init(int year, int monthOfYear, int dayOfMonth, boolean canPickRange,
-    public void init(SelectedDate selectedDate, boolean canPickRange,
+    public void init(SelectedDate selectedDate, boolean canPickRange, boolean isMultipleDayPicker,
                      SublimeDatePicker.OnDateChangedListener callback) {
         //mCurrentDate.set(Calendar.YEAR, year);
         //mCurrentDate.set(Calendar.MONTH, monthOfYear);
         //mCurrentDate.set(Calendar.DAY_OF_MONTH, dayOfMonth);
         mCurrentDate = new SelectedDate(selectedDate);
-
+        this.isAlternateDatePicker = isMultipleDayPicker;
         mDayPickerView.setCanPickRange(canPickRange);
         mDateChangedListener = callback;
-
         onDateChanged(false, false, true);
     }
 

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/helpers/SublimeOptions.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/helpers/SublimeOptions.java
@@ -61,6 +61,9 @@ public class SublimeOptions implements Parcelable {
     // Allow date range selection
     private boolean mCanPickDateRange;
 
+    //allow alternate selection mode
+    private boolean isAlternateSelection;
+
     // Defaults
     private Picker mPickerToShow = Picker.DATE_PICKER;
 
@@ -311,6 +314,15 @@ public class SublimeOptions implements Parcelable {
 
     public boolean canPickDateRange() {
         return mCanPickDateRange;
+    }
+
+    public SublimeOptions setAlternateSelectionMode(boolean isAlternateSelection) {
+        this.isAlternateSelection = isAlternateSelection;
+        return this;
+    }
+
+    public boolean isAlternateSelectionMode() {
+        return isAlternateSelection;
     }
 
     @Override

--- a/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/utilities/Config.java
+++ b/sublimepickerlibrary/src/main/java/com/appeaser/sublimepickerlibrary/utilities/Config.java
@@ -1,11 +1,13 @@
 package com.appeaser.sublimepickerlibrary.utilities;
 
+import com.appeaser.sublimepickerlibrary.BuildConfig;
+
 /**
  * Created by Admin on 13/02/2016.
  */
 public class Config {
 
-    public static final boolean DEBUG = false;
+    public static final boolean DEBUG = BuildConfig.DEBUG;
 
     @SuppressWarnings("unused")
     public static final int DEBUG_VERSION = 2;


### PR DESCRIPTION
Added a new way to select date ranges, similar to the one Airbnb uses. 

After the user selects the first date and chooses a second date, it will automatically create a range between those two dates.
Ex: I first select 2nd of March and then select 10th of March it will select this date range without the need to long press and drag.

If you want to select another date, just chose a date and you can go through the process of range selection again.